### PR TITLE
Fix empty lines in sudoers

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,6 +9,10 @@ users_default_shell: /bin/bash
 # Create home dirs for new users? Set this to false if you manage home
 # directories in some other way.
 users_create_homedirs: true
+# allow disabling 'no_log' (which is useful during testing and if a tasks fails!)
+# Note: In ansible v2 no need to add no_log to all tasks. There's a new global var, see:
+# https://github.com/ansible/ansible/pull/12528
+no_log: yes
 
 # Lists of users to create and delete
 users: []

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,7 +9,7 @@
   with_items: users
   when: users_create_per_user_group
   tags: ['users','configuration']
-  no_log: yes
+  no_log: "{{no_log}}"
 
 - name: User creation
   user: name="{{item.username}}"
@@ -26,7 +26,7 @@
 
   with_items: users
   tags: ['users','configuration']
-  no_log: yes
+  no_log: "{{no_log}}"
 
 - name: SSH keys
   authorized_key: user="{{item.0.username}}" key="{{item.1}}" key_options="{{item.0.ssh_key_opts|default(omit)}}"
@@ -34,12 +34,12 @@
     - users
     - ssh_key
   tags: ['users','configuration']
-  no_log: yes
+  no_log: "{{no_log}}"
 
 - name: Create ansible sudoers in temp directory
   template: src=etc/sudoers.d/ansible.j2 dest=/tmp/ansible
   tags: ['users','configuration']
-  no_log: yes
+  no_log: "{{no_log}}"
 
 - name: Check ansible sudoers syntax
   command: visudo -cf /tmp/ansible

--- a/templates/etc/sudoers.d/ansible.j2
+++ b/templates/etc/sudoers.d/ansible.j2
@@ -2,5 +2,6 @@
 
 # Ansible-managed users with NOPASSWD
 {% for user in users %}
-{% if user.sudo is defined and user.sudo and user.nopasswd is defined and user.nopasswd %}{{ user.username }} ALL=(ALL) NOPASSWD:ALL {% endif %} 
+{% if user.sudo is defined and user.sudo and user.nopasswd is defined and user.nopasswd %}{{ user.username }} ALL=(ALL) NOPASSWD:ALL
+{% endif %}
 {% endfor %}


### PR DESCRIPTION
Desc: fix empty lines in sudoers, added for each user that had nopasswd disabled

Update: This also includes (was not on purpose) another useful commit, to allow disabling 'no_log' 
I just made a separate PR for the 1.feature/commit -> https://github.com/dvianello/ansible-users/pull/3
